### PR TITLE
Add new routes to create a landing page and others

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,7 +11,11 @@ app.use(express.static(path.join(__dirname, "static")));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-const port = parseInt(process.env.PORT || "8080") || 8080
+// get the prot from the deployment environment or use 8080 as default
+const port = parseInt(process.env.PORT || "8080") || 8080;
+
+// get the database url from the deployment environment
+const dbUrl = process.env.DATABASE_URL;
 
 configureRoutes(app);
 

--- a/server.js
+++ b/server.js
@@ -31,4 +31,8 @@ function configureRoutes(app) {
     app.get("/admin/cms", (req, res) => {
         res.sendFile(path.join(__dirname, "static", "cms.html"));
     });
+
+    app.get("/api/molecule", (req, res) => {
+        res.sendFile(path.join(__dirname, "static", "molfile", "dna1.gltf"));
+    });
 }

--- a/server.js
+++ b/server.js
@@ -1,22 +1,34 @@
 
 const express = require('express');
 const app = express();
-const path = require('path');
+const path = require("path");
 
-const enviroment = require('dotenv');
+const enviroment = require("dotenv");
 enviroment.config();
 
-app.set("/","html");
-app.use(express.static(path.join(__dirname,"static")));
+app.set("/", "html");
+app.use(express.static(path.join(__dirname, "static")));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
 const port = parseInt(process.env.PORT || "8080") || 8080
 
-app.get('/',(req,res) => {
-    res.render('index');
-});
+configureRoutes(app);
 
-app.listen(port,() => {
+app.listen(port, () => {
     console.log("listen on http://localhost:" + port);
 });
+
+function configureRoutes(app) {
+    app.get('/', (_req, res) => {
+        res.sendFile(path.join(__dirname, "static", "index.html"));
+    });
+
+    app.get('/molecule', (req, res) => {
+        res.sendFile(path.join(__dirname, "static", "molecule.html"));
+    });
+
+    app.get("/admin/cms", (req, res) => {
+        res.sendFile(path.join(__dirname, "static", "cms.html"));
+    });
+}

--- a/static/cms.html
+++ b/static/cms.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Content Management System</title>
+</head>
+
+<body>
+    <p> You will be able to upload chemical files here and schedule them to show in the AR app.</p>
+</body>
+
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -1,67 +1,14 @@
 <!DOCTYPE html>
-<html>
-    <head>
-        <title>Gesture Interactions - A-Frame & AR.js</title>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <link rel="stylesheet" href="styles.css">
+<html lang="en">
 
+<head>
+    <title>Molecule of the Month</title>
+</head>
 
-        <!--Build models rendered on the AR platform-->
-        <script src="build/aframe.min.js"></script>
-        <script src="build/aframe-ar.js"></script>
+<body>
+    <h1>Welcome to the Molecule of the Month Web AR application</h1>
 
-         <!--Build gestures function on the AR platform-->
-        <script src="build/gesture-detector.js"></script>
-        <script src="build/gesture-handler.js"></script>
-    </head>
+    <a href="/molecule">Open app</a>
+</body>
 
-    <body style="margin: 0px; overflow: hidden;">
-        <!--Build scene-->
-        <a-scene 
-        embedded 
-        arjs
-        renderer="logarithmicDepthBuffer: true;"
-        vr-mode-ui="enabled: false"
-        gesture-detector
-        id="scene"
-        >
-            <!--Add marker (hiro) in the scene-->
-            <a-assets>
-                <a-asset-item
-                  id="bowser"
-                  src="molfile/dna1.gltf"
-                >
-                </a-asset-item>
-              </a-assets>
-            <a-marker 
-            preset="hiro"
-            raycaster="objects:clickable"
-            emitevents="true"
-            cursor="fuse: false; rayOrigin: mouse;"
-            id="markerA"
-            >
-                <!--Define what model will be rendered on top of the marker-->
-                <!--Position (x,y,z)-->
-                <!--Render gltf model file-->
-
-                <a-entity
-                    position="0 1 0"
-                    rotation="90 0 0"
-                    scale="0.05 0.05 0.05"
-                    gltf-model="#bowser"
-                    class="clickable"
-                    gesture-handler
-                ></a-entity>
-                <a-entity
-                    position="0 0 -1"
-                    scale="1 1 1"
-                    text="width:5; lineHeight:60; letterSpacing:3; color:white; value:Welcome to use this web app. Please contact us if you find any problem."
-                    rotation="-60 0 0">
-                </a-entity>
-            </a-marker>
-            <a-entity camera></a-entity>
-        </a-scene>
-
-    </body>
 </html>

--- a/static/molecule.html
+++ b/static/molecule.html
@@ -26,7 +26,7 @@
         gesture-detector
         id="scene"
         >
-            <!--Add marker (hiro) in the scene-->
+            <!--Define what model will be rendered on top of the marker-->
             <a-assets>
                 <a-asset-item
                   id="bowser"
@@ -34,6 +34,7 @@
                 >
                 </a-asset-item>
               </a-assets>
+            <!--Add marker (hiro) in the scene-->
             <a-marker 
             preset="hiro"
             raycaster="objects:clickable"
@@ -41,7 +42,6 @@
             cursor="fuse: false; rayOrigin: mouse;"
             id="markerA"
             >
-                <!--Define what model will be rendered on top of the marker-->
                 <!--Position (x,y,z)-->
                 <!--Render gltf model file-->
 

--- a/static/molecule.html
+++ b/static/molecule.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Gesture Interactions - A-Frame & AR.js</title>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <link rel="stylesheet" href="styles.css">
+
+
+        <!--Build models rendered on the AR platform-->
+        <script src="build/aframe.min.js"></script>
+        <script src="build/aframe-ar.js"></script>
+
+         <!--Build gestures function on the AR platform-->
+        <script src="build/gesture-detector.js"></script>
+        <script src="build/gesture-handler.js"></script>
+    </head>
+
+    <body style="margin: 0px; overflow: hidden;">
+        <!--Build scene-->
+        <a-scene 
+        embedded 
+        arjs
+        renderer="logarithmicDepthBuffer: true;"
+        vr-mode-ui="enabled: false"
+        gesture-detector
+        id="scene"
+        >
+            <!--Add marker (hiro) in the scene-->
+            <a-assets>
+                <a-asset-item
+                  id="bowser"
+                  src="molfile/dna1.gltf"
+                >
+                </a-asset-item>
+              </a-assets>
+            <a-marker 
+            preset="hiro"
+            raycaster="objects:clickable"
+            emitevents="true"
+            cursor="fuse: false; rayOrigin: mouse;"
+            id="markerA"
+            >
+                <!--Define what model will be rendered on top of the marker-->
+                <!--Position (x,y,z)-->
+                <!--Render gltf model file-->
+
+                <a-entity
+                    position="0 1 0"
+                    rotation="90 0 0"
+                    scale="0.05 0.05 0.05"
+                    gltf-model="#bowser"
+                    class="clickable"
+                    gesture-handler
+                ></a-entity>
+                <a-entity
+                    position="0 0 -1"
+                    scale="1 1 1"
+                    text="width:5; lineHeight:60; letterSpacing:3; color:white; value:Welcome to use this web app. Please contact us if you find any problem."
+                    rotation="-60 0 0">
+                </a-entity>
+            </a-marker>
+            <a-entity camera></a-entity>
+        </a-scene>
+
+    </body>
+</html>


### PR DESCRIPTION
Creates some new routes and reconfigures the index to be a landing page

- `/molecule` represents to old app
- `/admin/cms` could be used for the CMS to be developed
- `/api/molecule` could be an API endpoint to deliver the molecule file (.pdb or .gltf)

There is also a small change to load the database url, but it doesn't do anything with it yet.